### PR TITLE
Fix: Support #MEASUREBS

### DIFF
--- a/src/lib/sus/analyze.ts
+++ b/src/lib/sus/analyze.ts
@@ -78,8 +78,7 @@ export function analyze(sus: string, ticksPerBeat: number): Score {
         })
         .reverse()
 
-    const toTick: ToTick = (susMeasure, p, q) => {
-        const measure = susMeasure
+    const toTick: ToTick = (measure, p, q) => {
         const bar = bars.find((bar) => measure >= bar.measure)
         if (!bar) throw 'Unexpected missing bar'
 


### PR DESCRIPTION
This PR adds support for `#MEASUREBS`.
It is an offset for measure, like:
```
#00116:...  # <- 1st measure
#MEASUREBS 1000
#00116:...  # <- 1001st measure
#00216:...  # <- 1002st measure
#MEASUREBS 0
#00216:...  # <- 2nd measure
```
This is also fix for the bug that you can't make a chart with over 1000 measures.

(I'm new to TypeScript, so code may be dirty)