### PR TITLE
Critical Notes

### DIFF
--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
@@ -20,8 +20,10 @@ export class CriticalFlickNote extends SingleFlickNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalFlickNoteCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalFlickNoteLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     arrowSprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
@@ -20,8 +20,10 @@ export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalFLickNoteCircular
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalFlickNoteLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     arrowSprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
@@ -20,7 +20,7 @@ export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
     }
 
     effects = {
-        circular: particle.effects.criticalFLickNoteCircular
+        circular: particle.effects.criticalFlickNoteCircular,
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
@@ -20,8 +20,10 @@ export class CriticalSlideEndNote extends SlideEndNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalHoldNoteCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalHoldNoteEndLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     windows = windows.slideEndNote.critical

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -20,8 +20,10 @@ export class CriticalSlideStartNote extends SlideStartNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalHoldNoteCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalHoldNoteEndLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     windows = windows.slideStartNote.critical

--- a/play/src/engine/playData/particle.mts
+++ b/play/src/engine/playData/particle.mts
@@ -19,7 +19,12 @@ export const particle = defineParticle({
         criticalNoteCircular: ParticleEffectName.NoteCircularTapYellow,
         criticalNoteLinear: ParticleEffectName.NoteLinearTapYellow,
         criticalNoteDirectional: ParticleEffectName.NoteLinearAlternativeYellow,
-
+        criticalFlickNoteCircular: 'Sekai Critical Flick Circular',
+        criticalFlickNoteLinear: 'Sekai Critical Flick Linear',
+        criticalHoldNoteCircular: 'Sekai Critical Hold Circular',
+        criticalHoldNoteStartLinear: 'Sekai Critical Hold Start Linear',
+        criticalHoldNoteEndLinear: 'Sekai Critical Hold End Linear',
+        
         normalTraceNoteCircular: 'Sekai Trace Note Circular Green',
         normalTraceNoteLinear: 'Sekai Trace Note Linear Green',
 

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
@@ -20,8 +20,10 @@ export class CriticalFlickNote extends FlickNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalFlickNoteCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalFlickNoteLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     arrowSprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
@@ -20,8 +20,10 @@ export class CriticalSlideEndFlickNote extends FlickNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalFlickNoteCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalFlickNoteLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     arrowSprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -20,8 +20,10 @@ export class CriticalSlideStartNote extends SlideStartNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalHoldNoteCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalHoldNoteStartLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     windows = windows.slideStartNote.critical

--- a/watch/src/engine/watchData/particle.mts
+++ b/watch/src/engine/watchData/particle.mts
@@ -19,6 +19,11 @@ export const particle = defineParticle({
         criticalNoteCircular: ParticleEffectName.NoteCircularTapYellow,
         criticalNoteLinear: ParticleEffectName.NoteLinearTapYellow,
         criticalNoteDirectional: ParticleEffectName.NoteLinearAlternativeYellow,
+        criticalFlickNoteCircular: 'Sekai Critical Flick Circular',
+        criticalFlickNoteLinear: 'Sekai Critical Flick Linear',
+        criticalHoldNoteCircular: 'Sekai Critical Hold Circular',
+        criticalHoldNoteStartLinear: 'Sekai Critical Hold Start Linear',
+        criticalHoldNoteEndLinear: 'Sekai Critical Hold End Linear',
 
         normalTraceNoteCircular: 'Sekai Trace Note Circular Green',
         normalTraceNoteLinear: 'Sekai Trace Note Linear Green',


### PR DESCRIPTION
Updated the following:
PLAY MODE:
- particles (added Critical Flick and Critical Hold)
- Critical Hold, Start and End Notes (changed effects to match particles.mts)
- Critical Flick Notes - Single and Hold End
(changed effects to match particles.mts)

WATCH MODE:
- particles (added Critical Flick and Critical Hold)
- Critical Hold Start Notes (changed effects to match particles.mts) [there is no file for HoldEndNote]
- Critical Flick Notes - Single and Hold End
(changed effects to match particles.mts)