### PR TITLE
Updated SFX for Slider Tap Notes

### DIFF
--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
@@ -15,8 +15,7 @@ export class CriticalSlideEndNote extends SlideEndNote {
     }
 
     clips = {
-        perfect: effect.clips.criticalTap,
-        fallback: effect.clips.normalPerfect,
+        perfect: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.mts
@@ -16,8 +16,6 @@ export class NormalSlideEndNote extends SlideEndNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalPerfect,
-        good: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.mts
@@ -16,8 +16,8 @@ export class NormalSlideEndNote extends SlideEndNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalGreat,
-        good: effect.clips.normalGood,
+        great: effect.clips.normalPerfect,
+        good: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -15,8 +15,7 @@ export class CriticalSlideStartNote extends SlideStartNote {
     }
 
     clips = {
-        perfect: effect.clips.criticalTap,
-        fallback: effect.clips.normalPerfect,
+        perfect: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
@@ -16,8 +16,8 @@ export class NormalSlideStartNote extends SlideStartNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalGreat,
-        good: effect.clips.normalGood,
+        great: effect.clips.normalPerfect,
+        good: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
@@ -16,8 +16,6 @@ export class NormalSlideStartNote extends SlideStartNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalPerfect,
-        good: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
@@ -15,8 +15,7 @@ export class CriticalSlideEndNote extends FlatNote {
     }
 
     clips = {
-        perfect: effect.clips.criticalTap,
-        fallback: effect.clips.normalPerfect,
+        perfect: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalSlideEndNote.mts
@@ -16,8 +16,6 @@ export class NormalSlideEndNote extends FlatNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalPerfect,
-        good: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalSlideEndNote.mts
@@ -16,8 +16,8 @@ export class NormalSlideEndNote extends FlatNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalGreat,
-        good: effect.clips.normalGood,
+        great: effect.clips.normalPerfect,
+        good: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -15,8 +15,7 @@ export class CriticalSlideStartNote extends SlideStartNote {
     }
 
     clips = {
-        perfect: effect.clips.criticalTap,
-        fallback: effect.clips.normalPerfect,
+        perfect: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
@@ -16,8 +16,8 @@ export class NormalSlideStartNote extends SlideStartNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalGreat,
-        good: effect.clips.normalGood,
+        great: effect.clips.normalPerfect,
+        good: effect.clips.normalPerfect,
     }
 
     effects = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.mts
@@ -16,8 +16,6 @@ export class NormalSlideStartNote extends SlideStartNote {
 
     clips = {
         perfect: effect.clips.normalPerfect,
-        great: effect.clips.normalPerfect,
-        good: effect.clips.normalPerfect,
     }
 
     effects = {


### PR DESCRIPTION
Changed every SlideStart and SlideEnd SFX to **normalPerfect**.

[NormalSlideStart and NormalSlideEnd]
- Right now, the engine plays the perfect/great/good SFX depending on the judgment, which is not the case in the main game--- it plays the same normalPerfect SFX regardless of the judgment.
(Game clip) https://youtu.be/0waptPW6ew0

[CriticalSlideStart and CriticalSlideEnd]
- The engine plays criticalTap SFX, which is different from the main game, which plays the normalPerfect SFX.
(Game clip @0:05) https://youtu.be/qkHYm7WCOs8?si=D2fgRu3lVxgQjF9A 