### PR TITLE
particle change

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ npm install sonolus-pjsekai-engine
 | `Sekai Critical Slide End Circular Yellow` |
 | `Sekai Critical Slide End Linear Yellow`   |
 | `Sekai Critical Flick Circular Yellow`     |
+| `Sekai Critical Flick Linear Yellow`       |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ npm install sonolus-pjsekai-engine
 
 ### Particle Effects
 
-| Name                                       |
-| ------------------------------------------ |
-| `Sekai Trace Note Circular Green`          |
-| `Sekai Trace Note Linear Green`            |
-| `Sekai Trace Note Circular Yellow`         |
-| `Sekai Trace Note Linear Yellow`           |
-| `Sekai Note Lane Linear`                   |
-| `Sekai Critical Lane Linear`               |
-| `Sekai Critical Flick Lane Linear`         |
-| `Sekai Critical Slide Circular Yellow`     |
-| `Sekai Critical Slide Linear Yellow`       |
-| `Sekai Critical Flick Circular Yellow`     |
-| `Sekai Critical Flick Linear Yellow`       |
+| Name                                   |
+| -------------------------------------- |
+| `Sekai Trace Note Circular Green`      |
+| `Sekai Trace Note Linear Green`        |
+| `Sekai Trace Note Circular Yellow`     |
+| `Sekai Trace Note Linear Yellow`       |
+| `Sekai Note Lane Linear`               |
+| `Sekai Critical Lane Linear`           |
+| `Sekai Critical Flick Lane Linear`     |
+| `Sekai Critical Slide Circular Yellow` |
+| `Sekai Critical Slide Linear Yellow`   |
+| `Sekai Critical Flick Circular Yellow` |
+| `Sekai Critical Flick Linear Yellow`   |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ npm install sonolus-pjsekai-engine
 | `Sekai Trace Note Linear Yellow`           |
 | `Sekai Note Lane Linear`                   |
 | `Sekai Critical Lane Linear`               |
-| `Sekai Critical Slide End Circular Yellow` |
-| `Sekai Critical Slide End Linear Yellow`   |
+| `Sekai Critical Slide Circular Yellow` 
+|
+| `Sekai Critical Slide Linear Yellow`   
+|
 | `Sekai Critical Flick Circular Yellow`     |
 | `Sekai Critical Flick Linear Yellow`       |
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,9 @@ npm install sonolus-pjsekai-engine
 | `Sekai Trace Note Linear Yellow`           |
 | `Sekai Note Lane Linear`                   |
 | `Sekai Critical Lane Linear`               |
-| `Sekai Critical Slide Circular Yellow` 
-|
-| `Sekai Critical Slide Linear Yellow`   |
-| `Sekai Critical Flick Circular Yellow`    |
+| `Sekai Critical Slide Circular Yellow`     |
+| `Sekai Critical Slide Linear Yellow`       |
+| `Sekai Critical Flick Circular Yellow`     |
 | `Sekai Critical Flick Linear Yellow`       |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ npm install sonolus-pjsekai-engine
 | `Sekai Critical Lane Linear`               |
 | `Sekai Critical Slide Circular Yellow` 
 |
-| `Sekai Critical Slide Linear Yellow`   
-|
-| `Sekai Critical Flick Circular Yellow`     |
+| `Sekai Critical Slide Linear Yellow`   |
+| `Sekai Critical Flick Circular Yellow`    |
 | `Sekai Critical Flick Linear Yellow`       |
 
 ## Documentation

--- a/play/src/engine/playData/archetypes/notes/flatNotes/FlatNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/FlatNote.mts
@@ -256,7 +256,7 @@ export abstract class FlatNote extends Note {
                     b: lane.b,
                     t: lane.t,
                 }),
-                0.3,
+                1,
                 false,
             )
         } else {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
@@ -24,7 +24,7 @@ export class CriticalFlickNote extends SingleFlickNote {
     effects = {
         circular: particle.effects.criticalFlickNoteCircular,
         circularFallback: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalFlickNoteLircular,
+        linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
     }
 

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
@@ -64,7 +64,7 @@ export class CriticalFlickNote extends SingleFlickNote {
 
     playLaneEffects() {
         if (particle.effects.criticalLane.exists) {
-            particle.effects.criticalLane.spawn(
+            particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,
                     r: this.import.lane + this.import.size,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
@@ -1,12 +1,12 @@
+import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../../buckets.mjs'
 import { effect } from '../../../../../effect.mjs'
+import { lane } from '../../../../../lane.mjs'
 import { particle } from '../../../../../particle.mjs'
 import { skin } from '../../../../../skin.mjs'
 import { archetypes } from '../../../../index.mjs'
 import { SingleFlickNote } from './SingleFlickNote.mjs'
-import { lane } from '../../../../../lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalFlickNote extends SingleFlickNote {
     sprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.mts
@@ -63,7 +63,7 @@ export class CriticalFlickNote extends SingleFlickNote {
     }
 
     playLaneEffects() {
-        if (particle.effects.criticalLane.exists) {
+        if (particle.effects.criticalFlickLane.exists) {
             particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/NormalFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/NormalFlickNote.mts
@@ -58,4 +58,8 @@ export class NormalFlickNote extends SingleFlickNote {
     get slotGlowEffect() {
         return archetypes.FlickSlotGlowEffect
     }
+
+    playLaneEffects() {
+        // removed
+    }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
@@ -24,7 +24,7 @@ export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
     effects = {
         circular: particle.effects.criticalFlickNoteCircular,
         circularFallback: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalFlickNoteLircular,
+        linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
     }
 

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
@@ -64,7 +64,7 @@ export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
 
     playLaneEffects() {
         if (particle.effects.criticalLane.exists) {
-            particle.effects.criticalLane.spawn(
+            particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,
                     r: this.import.lane + this.import.size,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
@@ -1,12 +1,12 @@
+import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../../buckets.mjs'
 import { effect } from '../../../../../effect.mjs'
+import { lane } from '../../../../../lane.mjs'
 import { particle } from '../../../../../particle.mjs'
 import { skin } from '../../../../../skin.mjs'
 import { archetypes } from '../../../../index.mjs'
 import { SlideEndFlickNote } from './SlideEndFlickNote.mjs'
-import { lane } from '../../../../../lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
     sprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.mts
@@ -63,7 +63,7 @@ export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
     }
 
     playLaneEffects() {
-        if (particle.effects.criticalLane.exists) {
+        if (particle.effects.criticalFlickLane.exists) {
             particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/NormalSlideEndFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/NormalSlideEndFlickNote.mts
@@ -58,4 +58,8 @@ export class NormalSlideEndFlickNote extends SlideEndFlickNote {
     get slotGlowEffect() {
         return archetypes.FlickSlotGlowEffect
     }
+
+    playLaneEffects() {
+        // removed
+    }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
@@ -62,8 +62,8 @@ export class CriticalTraceFlickNote extends TraceFlickNote {
     }
 
     playLaneEffects() {
-        if (particle.effects.criticalLane.exists) {
-            particle.effects.criticalLane.spawn(
+        if (particle.effects.criticalFlickLane.exists) {
+            particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,
                     r: this.import.lane + this.import.size,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
@@ -1,12 +1,12 @@
+import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../../buckets.mjs'
 import { effect } from '../../../../../effect.mjs'
+import { lane } from '../../../../../lane.mjs'
 import { particle } from '../../../../../particle.mjs'
 import { skin } from '../../../../../skin.mjs'
 import { archetypes } from '../../../../index.mjs'
 import { TraceFlickNote } from './TraceFlickNote.mjs'
-import { lane } from '../../../../../lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalTraceFlickNote extends TraceFlickNote {
     sprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
@@ -5,6 +5,8 @@ import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { SlideEndNote } from './SlideEndNote.mjs'
+import { lane } from '../../../../lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideEndNote extends SlideEndNote {
     sprites = {
@@ -35,5 +37,31 @@ export class CriticalSlideEndNote extends SlideEndNote {
 
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect
+    }
+
+    playLaneEffects() {
+        if (particle.effects.criticalLane.exists) {
+            particle.effects.criticalLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
+        } else {
+            particle.effects.lane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                0.3,
+                false,
+            )
+        }
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
@@ -1,12 +1,12 @@
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../buckets.mjs'
 import { effect } from '../../../../effect.mjs'
+import { lane } from '../../../../lane.mjs'
 import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { SlideEndNote } from './SlideEndNote.mjs'
-import { lane } from '../../../../lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideEndNote extends SlideEndNote {
     sprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
@@ -19,9 +19,9 @@ export class CriticalSlideEndNote extends SlideEndNote {
     }
 
     effects = {
-        circular: particle.effects.criticalSlideEndCircular,
+        circular: particle.effects.criticalSlideCircular,
         circularFallback: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalSlideEndLinear,
+        linear: particle.effects.criticalSlideLinear,
         linearFallback: particle.effects.criticalNoteLinear,
     }
 

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.mts
@@ -51,6 +51,17 @@ export class CriticalSlideEndNote extends SlideEndNote {
                 1,
                 false,
             )
+        } else if (particle.effects.noteLane.exists) {
+            particle.effects.noteLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
         } else {
             particle.effects.lane.spawn(
                 perspectiveLayout({

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -1,12 +1,12 @@
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../buckets.mjs'
 import { effect } from '../../../../effect.mjs'
+import { lane } from '../../../../lane.mjs'
 import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { SlideStartNote } from './SlideStartNote.mjs'
-import { lane } from '../../../../lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideStartNote extends SlideStartNote {
     sprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -51,6 +51,17 @@ export class CriticalSlideStartNote extends SlideStartNote {
                 1,
                 false,
             )
+        } else if (particle.effects.noteLane.exists) {
+            particle.effects.noteLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
         } else {
             particle.effects.lane.spawn(
                 perspectiveLayout({

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -19,8 +19,10 @@ export class CriticalSlideStartNote extends SlideStartNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalSlideCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalSlideLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     windows = windows.slideStartNote.critical

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -5,6 +5,8 @@ import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { SlideStartNote } from './SlideStartNote.mjs'
+import { lane } from '../../../../lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideStartNote extends SlideStartNote {
     sprites = {
@@ -35,5 +37,31 @@ export class CriticalSlideStartNote extends SlideStartNote {
 
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect
+    }
+
+    playLaneEffects() {
+        if (particle.effects.criticalLane.exists) {
+            particle.effects.criticalLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
+        } else {
+            particle.effects.lane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                0.3,
+                false,
+            )
+        }
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.mts
@@ -50,6 +50,17 @@ export class CriticalTapNote extends TapNote {
                 1,
                 false,
             )
+        } else if (particle.effects.noteLane.exists) {
+            particle.effects.noteLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
         } else {
             particle.effects.lane.spawn(
                 perspectiveLayout({

--- a/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.mts
@@ -1,12 +1,12 @@
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../buckets.mjs'
 import { effect } from '../../../../effect.mjs'
+import { lane } from '../../../../lane.mjs'
 import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { TapNote } from './TapNote.mjs'
-import { lane } from '../../../../lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalTapNote extends TapNote {
     sprites = {

--- a/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.mts
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.mts
@@ -5,6 +5,8 @@ import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { TapNote } from './TapNote.mjs'
+import { lane } from '../../../../lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalTapNote extends TapNote {
     sprites = {
@@ -34,5 +36,31 @@ export class CriticalTapNote extends TapNote {
 
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect
+    }
+
+    playLaneEffects() {
+        if (particle.effects.criticalLane.exists) {
+            particle.effects.criticalLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
+        } else {
+            particle.effects.lane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                0.3,
+                false,
+            )
+        }
     }
 }

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,7 +267,10 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = ease(EaseType.OutIn, normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4)
+                const adjustE = ease(
+                    EaseType.OutIn,
+                    normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4,
+                )
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -266,7 +266,7 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
+                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
 
                 this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
                 this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.5)

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,7 +267,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5 ? 0.7 + (normalA - 0.5) * 0.6 : normalA * 0.6
+                const adjustE = normalA > 0.5 ? 0.85 + (normalA - 0.5) * 0.3 : normalA * 0.3
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,7 +267,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const eased = ease(EaseType.InOut, normalA)
+                const eased = ease(EaseType.OutIn, normalA)
                 
                 this.sprites.normal.draw(layout, this.z, a * eased)
                 this.sprites.active.draw(layout, this.z, a * (1 - eased))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -268,8 +268,8 @@ export abstract class SlideConnector extends Archetype {
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
 
-                this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
-                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.5)
+                this.sprites.normal.draw(layout, this.z, a * (0.5 + 0.5 * normalA))
+                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.8)
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -266,8 +266,8 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const eased = ease(EaseType.OutIn, normalA)
+                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
+                const eased = ease(EaseType.InOut, normalA)
                 
                 this.sprites.normal.draw(layout, this.z, a * eased)
                 this.sprites.active.draw(layout, this.z, a * (1 - eased))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,9 +267,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5
-                    ? 0.7 + (normalA - 0.5) * 0.6
-                    : normalA * 0.6 
+                const adjustE = normalA > 0.5 ? 0.7 + (normalA - 0.5) * 0.6 : normalA * 0.6
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,10 +267,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = ease(
-                    EaseType.OutIn,
-                    normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4,
-                )
+                const adjustE = ease(EaseType.OutIn, normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4)
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,9 +267,10 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-
-                this.sprites.normal.draw(layout, this.z, a * normalA)
-                this.sprites.active.draw(layout, this.z, a * (1 - normalA))
+                const eased = ease(EaseType.InOut, normalA)
+                
+                this.sprites.normal.draw(layout, this.z, a * eased)
+                this.sprites.active.draw(layout, this.z, a * (1 - eased))
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,7 +267,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5 ? 0.75 + (normalA - 0.5) * 0.5 : normalA * 0.5
+                const adjustE = ease(EaseType.OutIn, normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4)
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,10 +267,12 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const eased = ease(EaseType.InOut, normalA)
-                
-                this.sprites.normal.draw(layout, this.z, a * eased)
-                this.sprites.active.draw(layout, this.z, a * (1 - eased))
+                const adjustE = normalA > 0.5
+                    ? 0.7 + (normalA - 0.5) * 0.6
+                    : normalA * 0.6 
+
+                this.sprites.normal.draw(layout, this.z, a * adjustE)
+                this.sprites.active.draw(layout, this.z, a * (1 - adjustE))
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -266,7 +266,7 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
+                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
                 const eased = ease(EaseType.InOut, normalA)
                 
                 this.sprites.normal.draw(layout, this.z, a * eased)

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,7 +267,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5 ? 0.85 + (normalA - 0.5) * 0.3 : normalA * 0.3
+                const adjustE = normalA > 0.5 ? 0.75 + (normalA - 0.5) * 0.5 : normalA * 0.5
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -266,7 +266,7 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
+                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
 
                 this.sprites.normal.draw(layout, this.z, a * (0.5 + 0.5 * normalA))
                 this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.8)

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -269,7 +269,7 @@ export abstract class SlideConnector extends Archetype {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
 
                 this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
-                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.3)
+                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.5)
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/SlideConnector.mts
@@ -267,13 +267,9 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = ease(
-                    EaseType.OutIn,
-                    normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4,
-                )
 
-                this.sprites.normal.draw(layout, this.z, a * adjustE)
-                this.sprites.active.draw(layout, this.z, a * (1 - adjustE))
+                this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
+                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.3)
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -237,7 +237,7 @@ export abstract class ActiveSlideConnector extends SlideConnector {
             },
             this.glowZ,
             Math.min(1, Math.max(0, (time.now - this.start.time) / 0.25)) *
-            ((Math.cos((time.now - this.start.time) * 8 * Math.PI / 2) + 1) / 20 + 0.2),
+                ((Math.cos(((time.now - this.start.time) * 8 * Math.PI) / 2) + 1) / 20 + 0.2),
         )
     }
 

--- a/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -222,7 +222,7 @@ export abstract class ActiveSlideConnector extends SlideConnector {
 
         const shear = 1 + 0.25 * options.slotEffectSize
         const h = 4 * options.slotEffectSize * scaledScreen.wToH
-        const w = 0.2
+        const w = 0.1
 
         this.glowSprite.draw(
             {
@@ -236,7 +236,8 @@ export abstract class ActiveSlideConnector extends SlideConnector {
                 y4: 1,
             },
             this.glowZ,
-            (Math.cos((time.now - this.start.time) * 8 * Math.PI) + 1) / 20 + 0.2,
+            Math.min(1, Math.max(0, (time.now - this.start.time) / 0.25)) *
+            ((Math.cos((time.now - this.start.time) * 8 * Math.PI / 2) + 1) / 20 + 0.2),
         )
     }
 

--- a/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -222,20 +222,21 @@ export abstract class ActiveSlideConnector extends SlideConnector {
 
         const shear = 1 + 0.25 * options.slotEffectSize
         const h = 4 * options.slotEffectSize * scaledScreen.wToH
+        const w = 0.2
 
         this.glowSprite.draw(
             {
-                x1: l,
-                x2: l * shear,
-                x3: r * shear,
-                x4: r,
+                x1: l - w,
+                x2: l * shear - w,
+                x3: r * shear + w,
+                x4: r + w,
                 y1: 1,
                 y2: 1 - h,
                 y3: 1 - h,
                 y4: 1,
             },
             this.glowZ,
-            (Math.cos((time.now - this.start.time) * 8 * Math.PI) + 1) / 20 + 0.1,
+            (Math.cos((time.now - this.start.time) * 8 * Math.PI) + 1) / 20 + 0.2,
         )
     }
 

--- a/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/play/src/engine/playData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -222,7 +222,7 @@ export abstract class ActiveSlideConnector extends SlideConnector {
 
         const shear = 1 + 0.25 * options.slotEffectSize
         const h = 4 * options.slotEffectSize * scaledScreen.wToH
-        const w = 0.1
+        const w = 0.15
 
         this.glowSprite.draw(
             {

--- a/play/src/engine/playData/archetypes/slotGlowEffects/SlotGlowEffect.mts
+++ b/play/src/engine/playData/archetypes/slotGlowEffects/SlotGlowEffect.mts
@@ -45,7 +45,7 @@ export abstract class SlotGlowEffect extends SpawnableArchetype({
         }
 
         const a = Math.unlerp(this.endTime, this.spawnData.startTime, time.now)
-        const p = 1 - a ** 3
+        const p = options.V3SlotEnabled ? 1 : 1 - a ** 3
 
         const t = 1 - this.layout.h * p
 

--- a/play/src/engine/playData/archetypes/slotGlowEffects/SlotGlowEffect.mts
+++ b/play/src/engine/playData/archetypes/slotGlowEffects/SlotGlowEffect.mts
@@ -45,7 +45,7 @@ export abstract class SlotGlowEffect extends SpawnableArchetype({
         }
 
         const a = Math.unlerp(this.endTime, this.spawnData.startTime, time.now)
-        const p = options.V3SlotEnabled ? 1 : 1 - a ** 3
+        const p = options.removeSlotA ? 1 : 1 - a ** 3
 
         const t = 1 - this.layout.h * p
 

--- a/play/src/engine/playData/archetypes/slotGlowEffects/SlotGlowEffect.mts
+++ b/play/src/engine/playData/archetypes/slotGlowEffects/SlotGlowEffect.mts
@@ -45,7 +45,7 @@ export abstract class SlotGlowEffect extends SpawnableArchetype({
         }
 
         const a = Math.unlerp(this.endTime, this.spawnData.startTime, time.now)
-        const p = options.removeSlotA ? 1 : 1 - a ** 3
+        const p = options.simplifySlotA ? Math.min(1, a / 0.03) : 1 - a ** 3;
 
         const t = 1 - this.layout.h * p
 

--- a/play/src/engine/playData/particle.mts
+++ b/play/src/engine/playData/particle.mts
@@ -7,6 +7,7 @@ export const particle = defineParticle({
         lane: ParticleEffectName.LaneLinear,
         noteLane: 'Sekai Note Lane Linear',
         criticalLane: 'Sekai Critical Lane Linear',
+        criticalFlickLane: 'Sekai Critical Flick Lane Linear',
 
         normalNoteCircular: ParticleEffectName.NoteCircularTapCyan,
         normalNoteLinear: ParticleEffectName.NoteLinearTapCyan,

--- a/play/src/engine/playData/particle.mts
+++ b/play/src/engine/playData/particle.mts
@@ -23,8 +23,8 @@ export const particle = defineParticle({
         criticalNoteDirectional: ParticleEffectName.NoteLinearAlternativeYellow,
         criticalFlickNoteCircular: 'Sekai Critical Flick Circular Yellow',
         criticalFlickNoteLinear: 'Sekai Critical Flick Linear Yellow',
-        criticalSlideEndCircular: 'Sekai Critical Slide End Circular Yellow',
-        criticalSlideEndLinear: 'Sekai Critical Slide End Linear Yellow',
+        criticalSlideCircular: 'Sekai Critical Slide Circular Yellow',
+        criticalSlideLinear: 'Sekai Critical Slide Linear Yellow',
 
         normalTraceNoteCircular: 'Sekai Trace Note Circular Green',
         normalTraceNoteLinear: 'Sekai Trace Note Linear Green',

--- a/shared/src/engine/configuration/options.mts
+++ b/shared/src/engine/configuration/options.mts
@@ -115,11 +115,11 @@ export const optionsDefinition = {
         step: 0.05,
         unit: Text.PercentageUnit,
     },
-    removeSlotA: {
-        name: 'Remove Slot Animation',
+    simplifySlotA: {
+        name: 'Simplify slot animation',
         scope: 'Sekai',
         type: 'toggle',
-        def: 0,
+        def: 1,
     },
     stageCover: {
         name: Text.StageCoverVertical,

--- a/shared/src/engine/configuration/options.mts
+++ b/shared/src/engine/configuration/options.mts
@@ -115,6 +115,12 @@ export const optionsDefinition = {
         step: 0.05,
         unit: Text.PercentageUnit,
     },
+    V3SlotEnabled: {
+        name: "V3 Style Slot Effect",
+        scope: 'Sekai',
+        type: 'toggle',
+        def: 1,
+    },
     stageCover: {
         name: Text.StageCoverVertical,
         advanced: true,

--- a/shared/src/engine/configuration/options.mts
+++ b/shared/src/engine/configuration/options.mts
@@ -116,7 +116,7 @@ export const optionsDefinition = {
         unit: Text.PercentageUnit,
     },
     V3SlotEnabled: {
-        name: "V3 Style Slot Effect",
+        name: 'V3 Style Slot Effect',
         scope: 'Sekai',
         type: 'toggle',
         def: 0,

--- a/shared/src/engine/configuration/options.mts
+++ b/shared/src/engine/configuration/options.mts
@@ -119,7 +119,7 @@ export const optionsDefinition = {
         name: "V3 Style Slot Effect",
         scope: 'Sekai',
         type: 'toggle',
-        def: 1,
+        def: 0,
     },
     stageCover: {
         name: Text.StageCoverVertical,

--- a/shared/src/engine/configuration/options.mts
+++ b/shared/src/engine/configuration/options.mts
@@ -115,8 +115,8 @@ export const optionsDefinition = {
         step: 0.05,
         unit: Text.PercentageUnit,
     },
-    V3SlotEnabled: {
-        name: 'V3 Style Slot Effect',
+    removeSlotA: {
+        name: 'Remove Slot Animation',
         scope: 'Sekai',
         type: 'toggle',
         def: 0,

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -2,7 +2,7 @@ export enum EaseType {
     Out = -1,
     Linear = 0,
     In = 1,
-    InOut = 2,
+    OutIn = 2,
 }
 
 export const ease = (ease: EaseType, s: number) => {
@@ -11,8 +11,8 @@ export const ease = (ease: EaseType, s: number) => {
             return Math.ease('In', 'Quad', s)
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
-        case EaseType.InOut:
-                return Math.ease('InOut', 'Circ', s)
+        case EaseType.OutIn:
+                return Math.ease('OutIn', 'Circ', s)
         default:
             return s
     }

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -2,7 +2,7 @@ export enum EaseType {
     Out = -1,
     Linear = 0,
     In = 1,
-    OutIn = 2,
+    InOut = 2,
 }
 
 export const ease = (ease: EaseType, s: number) => {
@@ -11,8 +11,8 @@ export const ease = (ease: EaseType, s: number) => {
             return Math.ease('In', 'Quad', s)
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
-        case EaseType.OutIn:
-                return Math.ease('OutIn', 'Circ', s)
+        case EaseType.InOut:
+                return Math.ease('InOut', 'Quint', s)
         default:
             return s
     }

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -2,6 +2,7 @@ export enum EaseType {
     Out = -1,
     Linear = 0,
     In = 1,
+    OutIn = 2,
 }
 
 export const ease = (ease: EaseType, s: number) => {
@@ -10,6 +11,8 @@ export const ease = (ease: EaseType, s: number) => {
             return Math.ease('In', 'Quad', s)
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
+            case EaseType.OutIn:
+                return Math.ease('OutIn', 'Quart', s)
         default:
             return s
     }

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -11,8 +11,8 @@ export const ease = (ease: EaseType, s: number) => {
             return Math.ease('In', 'Quad', s)
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
-            case EaseType.OutIn:
-                return Math.ease('OutIn', 'Quart', s)
+        case EaseType.OutIn:
+            return Math.ease('OutIn', 'Quart', s)
         default:
             return s
     }

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -2,6 +2,7 @@ export enum EaseType {
     Out = -1,
     Linear = 0,
     In = 1,
+    InOut = 2,
 }
 
 export const ease = (ease: EaseType, s: number) => {
@@ -10,6 +11,8 @@ export const ease = (ease: EaseType, s: number) => {
             return Math.ease('In', 'Quad', s)
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
+        case EaseType.InOut:
+                return Math.ease('InOut', 'Circ', s)
         default:
             return s
     }

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -12,7 +12,7 @@ export const ease = (ease: EaseType, s: number) => {
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
         case EaseType.InOut:
-                return Math.ease('InOut', 'Quint', s)
+                return Math.ease('InOut', 'Circ', s)
         default:
             return s
     }

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -2,7 +2,6 @@ export enum EaseType {
     Out = -1,
     Linear = 0,
     In = 1,
-    OutIn = 2,
 }
 
 export const ease = (ease: EaseType, s: number) => {
@@ -11,8 +10,6 @@ export const ease = (ease: EaseType, s: number) => {
             return Math.ease('In', 'Quad', s)
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
-        case EaseType.OutIn:
-            return Math.ease('OutIn', 'Quart', s)
         default:
             return s
     }

--- a/shared/src/engine/data/EaseType.mts
+++ b/shared/src/engine/data/EaseType.mts
@@ -2,7 +2,6 @@ export enum EaseType {
     Out = -1,
     Linear = 0,
     In = 1,
-    InOut = 2,
 }
 
 export const ease = (ease: EaseType, s: number) => {
@@ -11,8 +10,6 @@ export const ease = (ease: EaseType, s: number) => {
             return Math.ease('In', 'Quad', s)
         case EaseType.Out:
             return Math.ease('Out', 'Quad', s)
-        case EaseType.InOut:
-                return Math.ease('InOut', 'Circ', s)
         default:
             return s
     }

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
@@ -5,6 +5,8 @@ import { particle } from '../../../particle.mjs'
 import { skin } from '../../../skin.mjs'
 import { archetypes } from '../../index.mjs'
 import { FlatNote } from './FlatNote.mjs'
+import { lane } from '../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideEndNote extends FlatNote {
     sprites = {
@@ -35,5 +37,31 @@ export class CriticalSlideEndNote extends FlatNote {
 
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect
+    }
+
+    playLaneEffects() {
+        if (particle.effects.criticalLane.exists) {
+            particle.effects.criticalLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
+        } else {
+            particle.effects.lane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                0.3,
+                false,
+            )
+        }
     }
 }

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
@@ -49,7 +49,7 @@ export class CriticalSlideEndNote extends FlatNote {
                     t: lane.t,
                 }),
                 1,
-                false,
+                false, 
             )
         } else {
             particle.effects.lane.spawn(

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
@@ -19,9 +19,9 @@ export class CriticalSlideEndNote extends FlatNote {
     }
 
     effects = {
-        circular: particle.effects.criticalSlideEndCircular,
+        circular: particle.effects.criticalSlideCircular,
         circularFallback: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalSlideEndLinear,
+        linear: particle.effects.criticalSlideLinear,
         linearFallback: particle.effects.criticalNoteLinear,
     }
 

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
@@ -51,6 +51,17 @@ export class CriticalSlideEndNote extends FlatNote {
                 1,
                 false,
             )
+        } else if (particle.effects.noteLane.exists) {
+            particle.effects.noteLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
         } else {
             particle.effects.lane.spawn(
                 perspectiveLayout({

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
@@ -1,3 +1,5 @@
+import { lane } from '../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../buckets.mjs'
 import { effect } from '../../../effect.mjs'
@@ -5,8 +7,6 @@ import { particle } from '../../../particle.mjs'
 import { skin } from '../../../skin.mjs'
 import { archetypes } from '../../index.mjs'
 import { FlatNote } from './FlatNote.mjs'
-import { lane } from '../../../../../../../shared/src/engine/data/lane.mjs'
-import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideEndNote extends FlatNote {
     sprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.mts
@@ -49,7 +49,7 @@ export class CriticalSlideEndNote extends FlatNote {
                     t: lane.t,
                 }),
                 1,
-                false, 
+                false,
             )
         } else {
             particle.effects.lane.spawn(

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.mts
@@ -1,3 +1,5 @@
+import { lane } from '../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../buckets.mjs'
 import { effect } from '../../../effect.mjs'
@@ -5,8 +7,6 @@ import { particle } from '../../../particle.mjs'
 import { skin } from '../../../skin.mjs'
 import { archetypes } from '../../index.mjs'
 import { FlatNote } from './FlatNote.mjs'
-import { lane } from '../../../../../../../shared/src/engine/data/lane.mjs'
-import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalTapNote extends FlatNote {
     sprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.mts
@@ -50,6 +50,17 @@ export class CriticalTapNote extends FlatNote {
                 1,
                 false,
             )
+        } else if (particle.effects.noteLane.exists) {
+            particle.effects.noteLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
         } else {
             particle.effects.lane.spawn(
                 perspectiveLayout({

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.mts
@@ -5,6 +5,8 @@ import { particle } from '../../../particle.mjs'
 import { skin } from '../../../skin.mjs'
 import { archetypes } from '../../index.mjs'
 import { FlatNote } from './FlatNote.mjs'
+import { lane } from '../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalTapNote extends FlatNote {
     sprites = {
@@ -34,5 +36,31 @@ export class CriticalTapNote extends FlatNote {
 
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect
+    }
+
+    playLaneEffects() {
+        if (particle.effects.criticalLane.exists) {
+            particle.effects.criticalLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
+        } else {
+            particle.effects.lane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                0.3,
+                false,
+            )
+        }
     }
 }

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/FlatNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/FlatNote.mts
@@ -264,7 +264,7 @@ export abstract class FlatNote extends Note {
                     b: lane.b,
                     t: lane.t,
                 }),
-                0.3,
+                1,
                 false,
             )
         } else {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
@@ -1,3 +1,5 @@
+import { lane } from '../../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../buckets.mjs'
 import { effect } from '../../../../effect.mjs'
@@ -5,8 +7,6 @@ import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { FlickNote } from './FlickNote.mjs'
-import { lane } from '../../../../../../../../shared/src/engine/data/lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalFlickNote extends FlickNote {
     sprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
@@ -24,7 +24,7 @@ export class CriticalFlickNote extends FlickNote {
     effects = {
         circular: particle.effects.criticalFlickNoteCircular,
         circularFallback: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalFlickNoteLircular,
+        linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
     }
 

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
@@ -62,7 +62,7 @@ export class CriticalFlickNote extends FlickNote {
         return archetypes.CriticalSlotGlowEffect
     }
     playLaneEffects() {
-        if (particle.effects.criticalLane.exists) {
+        if (particle.effects.criticalFlickLane.exists) {
             particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
@@ -24,7 +24,8 @@ export class CriticalFlickNote extends FlickNote {
     effects = {
         circular: particle.effects.criticalFlickNoteCircular,
         circularFallback: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        linear: particle.effects.criticalFlickNoteLircular,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     arrowSprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.mts
@@ -63,7 +63,7 @@ export class CriticalFlickNote extends FlickNote {
     }
     playLaneEffects() {
         if (particle.effects.criticalLane.exists) {
-            particle.effects.criticalLane.spawn(
+            particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,
                     r: this.import.lane + this.import.size,

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
@@ -63,7 +63,7 @@ export class CriticalSlideEndFlickNote extends FlickNote {
     }
 
     playLaneEffects() {
-        if (particle.effects.criticalLane.exists) {
+        if (particle.effects.criticalFlickLane.exists) {
             particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
@@ -24,7 +24,8 @@ export class CriticalSlideEndFlickNote extends FlickNote {
     effects = {
         circular: particle.effects.criticalFlickNoteCircular,
         circularFallback: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        linear: particle.effects.criticalFlickNoteLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     arrowSprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
@@ -64,7 +64,7 @@ export class CriticalSlideEndFlickNote extends FlickNote {
 
     playLaneEffects() {
         if (particle.effects.criticalLane.exists) {
-            particle.effects.criticalLane.spawn(
+            particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,
                     r: this.import.lane + this.import.size,

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.mts
@@ -1,3 +1,5 @@
+import { lane } from '../../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../buckets.mjs'
 import { effect } from '../../../../effect.mjs'
@@ -5,8 +7,6 @@ import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { FlickNote } from './FlickNote.mjs'
-import { lane } from '../../../../../../../../shared/src/engine/data/lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideEndFlickNote extends FlickNote {
     sprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalFlickNote.mts
@@ -58,4 +58,7 @@ export class NormalFlickNote extends FlickNote {
     get slotGlowEffect() {
         return archetypes.FlickSlotGlowEffect
     }
+    playLaneEffects() {
+        // removed
+    }
 }

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalSlideEndFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalSlideEndFlickNote.mts
@@ -58,4 +58,7 @@ export class NormalSlideEndFlickNote extends FlickNote {
     get slotGlowEffect() {
         return archetypes.FlickSlotGlowEffect
     }
+    playLaneEffects() {
+        // removed
+    }
 }

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
@@ -62,8 +62,8 @@ export class CriticalTraceFlickNote extends TraceFlickNote {
     }
 
     playLaneEffects() {
-        if (particle.effects.criticalLane.exists) {
-            particle.effects.criticalLane.spawn(
+        if (particle.effects.criticalFlickLane.exists) {
+            particle.effects.criticalFlickLane.spawn(
                 perspectiveLayout({
                     l: this.import.lane - this.import.size,
                     r: this.import.lane + this.import.size,

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.mts
@@ -1,3 +1,5 @@
+import { lane } from '../../../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../../buckets.mjs'
 import { effect } from '../../../../../effect.mjs'
@@ -5,8 +7,6 @@ import { particle } from '../../../../../particle.mjs'
 import { skin } from '../../../../../skin.mjs'
 import { archetypes } from '../../../../index.mjs'
 import { TraceFlickNote } from './TraceFlickNote.mjs'
-import { lane } from '../../../../../../../../../shared/src/engine/data/lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalTraceFlickNote extends TraceFlickNote {
     sprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -1,3 +1,5 @@
+import { lane } from '../../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.mjs'
 import { buckets } from '../../../../buckets.mjs'
 import { effect } from '../../../../effect.mjs'
@@ -5,8 +7,6 @@ import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { SlideStartNote } from './SlideStartNote.mjs'
-import { lane } from '../../../../../../../../shared/src/engine/data/lane.mjs'
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideStartNote extends SlideStartNote {
     sprites = {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -49,7 +49,7 @@ export class CriticalSlideStartNote extends SlideStartNote {
                     t: lane.t,
                 }),
                 1,
-                false,
+                false, 
             )
         } else {
             particle.effects.lane.spawn(

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -51,6 +51,17 @@ export class CriticalSlideStartNote extends SlideStartNote {
                 1,
                 false,
             )
+        } else if (particle.effects.noteLane.exists) {
+            particle.effects.noteLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
         } else {
             particle.effects.lane.spawn(
                 perspectiveLayout({

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -19,8 +19,10 @@ export class CriticalSlideStartNote extends SlideStartNote {
     }
 
     effects = {
-        circular: particle.effects.criticalNoteCircular,
-        linear: particle.effects.criticalNoteLinear,
+        circular: particle.effects.criticalSlideCircular,
+        circularFallback: particle.effects.criticalNoteCircular,
+        linear: particle.effects.criticalSlideLinear,
+        linearFallback: particle.effects.criticalNoteLinear,
     }
 
     windows = windows.slideStartNote.critical

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -49,7 +49,7 @@ export class CriticalSlideStartNote extends SlideStartNote {
                     t: lane.t,
                 }),
                 1,
-                false, 
+                false,
             )
         } else {
             particle.effects.lane.spawn(

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.mts
@@ -5,6 +5,8 @@ import { particle } from '../../../../particle.mjs'
 import { skin } from '../../../../skin.mjs'
 import { archetypes } from '../../../index.mjs'
 import { SlideStartNote } from './SlideStartNote.mjs'
+import { lane } from '../../../../../../../../shared/src/engine/data/lane.mjs'
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.mjs'
 
 export class CriticalSlideStartNote extends SlideStartNote {
     sprites = {
@@ -35,5 +37,31 @@ export class CriticalSlideStartNote extends SlideStartNote {
 
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect
+    }
+
+    playLaneEffects() {
+        if (particle.effects.criticalLane.exists) {
+            particle.effects.criticalLane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                1,
+                false,
+            )
+        } else {
+            particle.effects.lane.spawn(
+                perspectiveLayout({
+                    l: this.import.lane - this.import.size,
+                    r: this.import.lane + this.import.size,
+                    b: lane.b,
+                    t: lane.t,
+                }),
+                0.3,
+                false,
+            )
+        }
     }
 }

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -208,8 +208,8 @@ export abstract class SlideConnector extends Archetype {
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
 
-                this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
-                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.5)
+                this.sprites.normal.draw(layout, this.z, a * (0.5 + 0.5 * normalA))
+                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.8)
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,7 +207,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5 ? 0.7 + (normalA - 0.5) * 0.6 : normalA * 0.6
+                const adjustE = normalA > 0.5 ? 0.85 + (normalA - 0.5) * 0.3 : normalA * 0.3
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,9 +207,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5
-                    ? 0.7 + (normalA - 0.5) * 0.6
-                    : normalA * 0.6 
+                const adjustE = normalA > 0.5 ? 0.7 + (normalA - 0.5) * 0.6 : normalA * 0.6
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,9 +207,10 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-
-                this.sprites.normal.draw(layout, this.z, a * normalA)
-                this.sprites.active.draw(layout, this.z, a * (1 - normalA))
+                const eased = ease(EaseType.InOut, normalA)
+                
+                this.sprites.normal.draw(layout, this.z, a * eased)
+                this.sprites.active.draw(layout, this.z, a * (1 - eased))
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,7 +207,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const eased = ease(EaseType.InOut, normalA)
+                const eased = ease(EaseType.OutIn, normalA)
                 
                 this.sprites.normal.draw(layout, this.z, a * eased)
                 this.sprites.active.draw(layout, this.z, a * (1 - eased))

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,7 +207,10 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = ease(EaseType.OutIn, normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4)
+                const adjustE = ease(
+                    EaseType.OutIn,
+                    normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4,
+                )
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -206,8 +206,8 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const eased = ease(EaseType.OutIn, normalA)
+                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
+                const eased = ease(EaseType.InOut, normalA)
                 
                 this.sprites.normal.draw(layout, this.z, a * eased)
                 this.sprites.active.draw(layout, this.z, a * (1 - eased))

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,7 +207,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5 ? 0.85 + (normalA - 0.5) * 0.3 : normalA * 0.3
+                const adjustE = normalA > 0.5 ? 0.75 + (normalA - 0.5) * 0.5 : normalA * 0.5
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -206,7 +206,7 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
+                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
 
                 this.sprites.normal.draw(layout, this.z, a * (0.5 + 0.5 * normalA))
                 this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.8)

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -209,7 +209,7 @@ export abstract class SlideConnector extends Archetype {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
 
                 this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
-                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.3)
+                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.5)
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,13 +207,9 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = ease(
-                    EaseType.OutIn,
-                    normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4,
-                )
 
-                this.sprites.normal.draw(layout, this.z, a * adjustE)
-                this.sprites.active.draw(layout, this.z, a * (1 - adjustE))
+                this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
+                this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.3)
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,10 +207,12 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const eased = ease(EaseType.InOut, normalA)
-                
-                this.sprites.normal.draw(layout, this.z, a * eased)
-                this.sprites.active.draw(layout, this.z, a * (1 - eased))
+                const adjustE = normalA > 0.5
+                    ? 0.7 + (normalA - 0.5) * 0.6
+                    : normalA * 0.6 
+
+                this.sprites.normal.draw(layout, this.z, a * adjustE)
+                this.sprites.active.draw(layout, this.z, a * (1 - adjustE))
             } else {
                 this.sprites.normal.draw(layout, this.z, a)
             }

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -206,7 +206,7 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
+                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
 
                 this.sprites.normal.draw(layout, this.z, a * (0.7 + 0.3 * normalA))
                 this.sprites.active.draw(layout, this.z, a * (1 - normalA) * 0.5)

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -207,7 +207,7 @@ export abstract class SlideConnector extends Archetype {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
                 const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
-                const adjustE = normalA > 0.5 ? 0.75 + (normalA - 0.5) * 0.5 : normalA * 0.5
+                const adjustE = ease(EaseType.OutIn, normalA > 0.5 ? 0.8 + (normalA - 0.5) * 0.4 : normalA * 0.4)
 
                 this.sprites.normal.draw(layout, this.z, a * adjustE)
                 this.sprites.active.draw(layout, this.z, a * (1 - adjustE))

--- a/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/SlideConnector.mts
@@ -206,7 +206,7 @@ export abstract class SlideConnector extends Archetype {
             if (this.useFallbackSprite) {
                 this.sprites.fallback.draw(layout, this.z, a)
             } else if (options.connectorAnimation && this.visual === VisualType.Activated) {
-                const normalA = (Math.cos((time.now - this.start.time) * 4 * Math.PI) + 1) / 2
+                const normalA = (Math.cos((time.now - this.start.time) * 2 * Math.PI) + 1) / 2
                 const eased = ease(EaseType.InOut, normalA)
                 
                 this.sprites.normal.draw(layout, this.z, a * eased)

--- a/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -135,7 +135,7 @@ export abstract class ActiveSlideConnector extends SlideConnector {
 
         const shear = 1 + 0.25 * options.slotEffectSize
         const h = 4 * options.slotEffectSize * scaledScreen.wToH
-        const w = 0.1
+        const w = 0.15
 
         this.glowSprite.draw(
             {

--- a/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -135,20 +135,21 @@ export abstract class ActiveSlideConnector extends SlideConnector {
 
         const shear = 1 + 0.25 * options.slotEffectSize
         const h = 4 * options.slotEffectSize * scaledScreen.wToH
+        const w = 0.2
 
         this.glowSprite.draw(
             {
-                x1: l,
-                x2: l * shear,
-                x3: r * shear,
-                x4: r,
+                x1: l - w,
+                x2: l * shear - w,
+                x3: r * shear + w,
+                x4: r + w,
                 y1: 1,
                 y2: 1 - h,
                 y3: 1 - h,
                 y4: 1,
             },
             this.glowZ,
-            (Math.cos((time.now - this.start.time) * 8 * Math.PI) + 1) / 20 + 0.1,
+            (Math.cos((time.now - this.start.time) * 8 * Math.PI) + 1) / 20 + 0.2,
         )
     }
 

--- a/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -150,7 +150,7 @@ export abstract class ActiveSlideConnector extends SlideConnector {
             },
             this.glowZ,
             Math.min(1, Math.max(0, (time.now - this.start.time) / 0.25)) *
-            ((Math.cos((time.now - this.start.time) * 8 * Math.PI / 2) + 1) / 20 + 0.2),
+                ((Math.cos(((time.now - this.start.time) * 8 * Math.PI) / 2) + 1) / 20 + 0.2),
         )
     }
 

--- a/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
+++ b/watch/src/engine/watchData/archetypes/slideConnectors/activeSlideConnectors/ActiveSlideConnector.mts
@@ -135,7 +135,7 @@ export abstract class ActiveSlideConnector extends SlideConnector {
 
         const shear = 1 + 0.25 * options.slotEffectSize
         const h = 4 * options.slotEffectSize * scaledScreen.wToH
-        const w = 0.2
+        const w = 0.1
 
         this.glowSprite.draw(
             {
@@ -149,7 +149,8 @@ export abstract class ActiveSlideConnector extends SlideConnector {
                 y4: 1,
             },
             this.glowZ,
-            (Math.cos((time.now - this.start.time) * 8 * Math.PI) + 1) / 20 + 0.2,
+            Math.min(1, Math.max(0, (time.now - this.start.time) / 0.25)) *
+            ((Math.cos((time.now - this.start.time) * 8 * Math.PI / 2) + 1) / 20 + 0.2),
         )
     }
 

--- a/watch/src/engine/watchData/archetypes/slotGlowEffects/SlotGlowEffect.mts
+++ b/watch/src/engine/watchData/archetypes/slotGlowEffects/SlotGlowEffect.mts
@@ -48,7 +48,7 @@ export abstract class SlotGlowEffect extends SpawnableArchetype({
 
     updateParallel() {
         const a = Math.unlerp(this.endTime, this.spawnData.startTime, time.now)
-        const p = options.removeSlotA ? 1 : 1 - a ** 3
+        const p = options.simplifySlotA ? Math.min(1, a / 0.03) : 1 - a ** 3;
 
         const t = 1 - this.layout.h * p
 

--- a/watch/src/engine/watchData/archetypes/slotGlowEffects/SlotGlowEffect.mts
+++ b/watch/src/engine/watchData/archetypes/slotGlowEffects/SlotGlowEffect.mts
@@ -48,7 +48,7 @@ export abstract class SlotGlowEffect extends SpawnableArchetype({
 
     updateParallel() {
         const a = Math.unlerp(this.endTime, this.spawnData.startTime, time.now)
-        const p = options.V3SlotEnabled ? 1 : 1 - a ** 3
+        const p = options.removeSlotA ? 1 : 1 - a ** 3
 
         const t = 1 - this.layout.h * p
 

--- a/watch/src/engine/watchData/archetypes/slotGlowEffects/SlotGlowEffect.mts
+++ b/watch/src/engine/watchData/archetypes/slotGlowEffects/SlotGlowEffect.mts
@@ -48,7 +48,7 @@ export abstract class SlotGlowEffect extends SpawnableArchetype({
 
     updateParallel() {
         const a = Math.unlerp(this.endTime, this.spawnData.startTime, time.now)
-        const p = 1 - a ** 3
+        const p = options.V3SlotEnabled ? 1 : 1 - a ** 3
 
         const t = 1 - this.layout.h * p
 

--- a/watch/src/engine/watchData/particle.mts
+++ b/watch/src/engine/watchData/particle.mts
@@ -7,6 +7,7 @@ export const particle = defineParticle({
         lane: ParticleEffectName.LaneLinear,
         noteLane: 'Sekai Note Lane Linear',
         criticalLane: 'Sekai Critical Lane Linear',
+        criticalFlickLane: 'Sekai Critical Flick Lane Linear',
 
         normalNoteCircular: ParticleEffectName.NoteCircularTapCyan,
         normalNoteLinear: ParticleEffectName.NoteLinearTapCyan,

--- a/watch/src/engine/watchData/particle.mts
+++ b/watch/src/engine/watchData/particle.mts
@@ -23,8 +23,8 @@ export const particle = defineParticle({
         criticalNoteDirectional: ParticleEffectName.NoteLinearAlternativeYellow,
         criticalFlickNoteCircular: 'Sekai Critical Flick Circular Yellow',
         criticalFlickNoteLinear: 'Sekai Critical Flick Linear Yellow',
-        criticalSlideEndCircular: 'Sekai Critical Slide End Circular Yellow',
-        criticalSlideEndLinear: 'Sekai Critical Slide End Linear Yellow',
+        criticalSlideCircular: 'Sekai Critical Slide Circular Yellow',
+        criticalSlideLinear: 'Sekai Critical Slide Linear Yellow',
 
         normalTraceNoteCircular: 'Sekai Trace Note Circular Green',
         normalTraceNoteLinear: 'Sekai Trace Note Linear Green',


### PR DESCRIPTION
I checked the comments of the previous pr with almost the same content. However, I am uploading this pr because there are quite a few complaints about the visual discrepancy with the original pjsekai in the critical note(In addition, some note effects) that was integrated into one.
***
Separation of lane effect when touching lane effect and note

Added gold flick lane effect

Added an effect for gold

Change slot glow effect animation and add option

All changes have a fallback added to ensure compatibility with the original resource.
***
In Sekai, different effects are played depending on the type of Gold Note. Accordingly, separate three types of effects. Gold Notes each possess unique lane effects and particle effects based on their type. (Sekai Critical Slide End Circular Yellow, Sekai Critical Slide End Linear Yellow, Sekai Critical Flick Circular Yellow, Sekai Critical Flick Linear Yellow)

Additionally, different Lane Effects were separated to ensure unique effects are played in four distinct cases: when simply touching the Lane, when touching a Note (Sekai Note Lane Linear), when touching a Gold Note (Sekai Critical Lane Linear), and when touching a Gold Flick Note (Sekai Critical Flick Lane Linear).

As Sekai moved to version 3.0, the animation in the slot effect disappeared. I modify on this

The slot effect that appears when holding a slide note has a higher alpha value and is slightly wider than the width of the slide note. I modify on this

The connector animation was adjusted to be closer to the original sekai by adding ease.